### PR TITLE
Fix warning by explicitly passing a hash

### DIFF
--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -5,7 +5,7 @@ module SidebarHelper
 
   def active_class(link_path)
     controller_name = link_path.split("/").second
-    current_page?(controller: controller_name, action: action_name) ? "active" : ""
+    current_page?({controller: controller_name, action: action_name}) ? "active" : ""
   rescue ActionController::UrlGenerationError
     ""
   end


### PR DESCRIPTION
Summary:
  - Ruby 3 requires you to now separate positional arguments from
    keyword arguments. We now are explicitly sending the arguments
    as a hash.

Full working out:

 - actionview/lib/action_view?helpers/url_helper.rb #current_page?
   takes an options hash followed by keyword argument:
   def current_page?(options, check_parameters: false)

 - in our code, sidebar_helper.rb is passing a keyword argument

 - Ruby 3.0 separates keyword arguments from positional arguments.
   In this case we're passing keyword arguments when it is *now*
   expecting the programmer to explicitly pass a hash.

  - solution is to mark the optional arguments with a hash

Reference:

https://www.ruby-lang.org/en/news/2019/12/12/
  separation-of-positional-and-keyword-arguments-in-ruby-3-0/

### What github issue is this PR for, if any?
Resolves #001

### What changed, and why?


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
